### PR TITLE
[MRG + 1] overhaul config and intra/inter setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/irit-melodi/educe.git#egg=educe
--e git+https://github.com/irit-melodi/attelo.git#egg=attelo
+-e git+https://github.com/kowey/educe.git@wip#egg=educe
+-e git+https://github.com/kowey/attelo.git@wip#egg=attelo
 -e git+https://github.com/nlhepler/pydot.git#egg=pydot
 -e .

--- a/stac/harness/config/common.py
+++ b/stac/harness/config/common.py
@@ -1,0 +1,118 @@
+"""Commonly used configuration options"""
+
+from collections import namedtuple
+import six
+# from attelo.decoding.astar import (AstarArgs,
+#                                    AstarDecoder,
+#                                    Heuristic,
+#                                    RfcConstraint)
+from attelo.decoding.baseline import (LastBaseline,
+                                      LocalBaseline)
+from attelo.harness.config import (EvaluationConfig,
+                                   LearnerConfig,
+                                   Keyed)
+from attelo.learning.oracle import (AttachOracle, LabelOracle)
+from attelo.parser.full import (JointPipeline,
+                                PostlabelPipeline)
+
+
+def combined_key(*variants):
+    """return a key from a list of objects that have a
+    `key` field each"""
+    return '-'.join(v if isinstance(v, six.string_types) else v.key
+                    for v in variants)
+
+
+Settings = namedtuple('Settings',
+                      ['key', 'intra', 'oracle', 'children'])
+"""
+Note that this is subclass of Keyed
+
+The settings are used for config management only, for example,
+if we want to filter in/out configurations that involve an
+oracle.
+
+Parameters
+----------
+intra: bool
+    If this config uses intra/inter decoding
+
+oracle: bool
+    If parser should be considered oracle-based
+
+children: container(Settings)
+    Any nested settings (eg. if intra/inter, this would be the
+    the settings of the intra and inter decoders)
+"""
+
+# ---------------------------------------------------------------------
+# oracles
+# ---------------------------------------------------------------------
+
+
+def attach_learner_oracle():
+    "return a keyed instance of the oracle (virtual) learner"
+    return Keyed('oracle', AttachOracle())
+
+
+def label_learner_oracle():
+    "return a keyed instance of the oracle (virtual) learner"
+    return Keyed('oracle', LabelOracle())
+
+
+ORACLE = LearnerConfig(attach=attach_learner_oracle(),
+                       label=label_learner_oracle())
+
+# ---------------------------------------------------------------------
+# baselines
+# ---------------------------------------------------------------------
+
+
+def decoder_last():
+    "our instantiation of the mst decoder"
+    return Keyed('last', LastBaseline())
+
+
+def decoder_local(threshold):
+    "our instantiation of the mst decoder"
+    return Keyed('local', LocalBaseline(threshold, True))
+
+# ---------------------------------------------------------------------
+# pipelines
+# ---------------------------------------------------------------------
+
+
+def _core_settings(key, klearner):
+    "settings for basic pipelines"
+    return Settings(key=key,
+                    intra=False,
+                    oracle='oracle' in klearner.key,
+                    children=None)
+
+
+def mk_joint(klearner, kdecoder):
+    "return a joint decoding parser config"
+    settings = _core_settings('AD.L-jnt', klearner)
+    parser_key = combined_key(settings, kdecoder)
+    key = combined_key(klearner, parser_key)
+    parser = JointPipeline(learner_attach=klearner.attach.payload,
+                           learner_label=klearner.label.payload,
+                           decoder=kdecoder.payload)
+    return EvaluationConfig(key=key,
+                            settings=settings,
+                            learner=klearner,
+                            parser=Keyed(parser_key, parser))
+
+
+def mk_post(klearner, kdecoder):
+    "return a post label parser"
+    settings = _core_settings('AD.L-pst', klearner)
+    parser_key = combined_key(settings, kdecoder)
+    key = combined_key(klearner, parser_key)
+    parser = PostlabelPipeline(learner_attach=klearner.attach.payload,
+                               learner_label=klearner.label.payload,
+                               decoder=kdecoder.payload)
+    return EvaluationConfig(key=key,
+                            settings=settings,
+                            learner=klearner,
+                            parser=Keyed(parser_key, parser))

--- a/stac/harness/config/intra.py
+++ b/stac/harness/config/intra.py
@@ -1,0 +1,44 @@
+"""Configuration helpers for using the intra-inter sentential stuff"""
+
+from attelo.harness.config import (EvaluationConfig,
+                                   Keyed)
+from .common import (Settings, combined_key)
+
+
+def combine_intra(econfs, kconf, primary='intra'):
+    """Combine a pair of EvaluationConfig into a single IntraInterParser
+
+    Parameters
+    ----------
+    econfs: IntraInterPair(EvaluationConfig)
+
+    kconf: Keyed(parser constructor)
+
+    primary: ['intra', 'inter']
+        Treat the intra/inter config as the primary one for the key
+    """
+    if primary == 'intra':
+        econf = econfs.intra
+    elif primary == 'inter':
+        econf = econfs.inter
+    else:
+        raise ValueError("'primary' should be one of intra/inter: " + primary)
+
+    parsers = econfs.fmap(lambda e: e.parser.payload)
+    subsettings = econfs.fmap(lambda e: e.settings)
+    learners = econfs.fmap(lambda e: e.learner)
+    settings = Settings(key=combined_key(kconf, econf.settings),
+                        intra=True,
+                        oracle=econf.settings.oracle,
+                        children=subsettings)
+    kparser = Keyed(combined_key(kconf, econf.parser),
+                    kconf.payload(parsers))
+    if learners.intra.key == learners.inter.key:
+        learner_key = learners.intra.key
+    else:
+        learner_key = '{}S_D{}'.format(learners.intra.key,
+                                       learners.inter.key)
+    return EvaluationConfig(key=combined_key(learner_key, kparser),
+                            settings=settings,
+                            learner=learners,
+                            parser=kparser)

--- a/stac/harness/config/perceptron.py
+++ b/stac/harness/config/perceptron.py
@@ -1,0 +1,104 @@
+"""Configuration helpers for using perceptron based learners
+"""
+
+import numpy as np
+from sklearn import linear_model as sk
+
+from attelo.harness.config import (Keyed)
+
+from attelo.learning.perceptron import (Perceptron,
+                                        PerceptronArgs,
+                                        PassiveAggressive,
+                                        StructuredPerceptron,
+                                        StructuredPassiveAggressive)
+from attelo.learning.local import (SklearnAttachClassifier,
+                                   SklearnLabelClassifier)
+
+
+LOCAL_PERC_ARGS = PerceptronArgs(iterations=20,
+                                 averaging=True,
+                                 use_prob=False,
+                                 aggressiveness=np.inf)
+
+LOCAL_PA_ARGS = PerceptronArgs(iterations=20,
+                               averaging=True,
+                               use_prob=False,
+                               aggressiveness=np.inf)
+
+STRUCT_PERC_ARGS = PerceptronArgs(iterations=50,
+                                  averaging=True,
+                                  use_prob=False,
+                                  aggressiveness=np.inf)
+
+STRUCT_PA_ARGS = PerceptronArgs(iterations=50,
+                                averaging=True,
+                                use_prob=False,
+                                aggressiveness=np.inf)
+
+# ---------------------------------------------------------------------
+# scikit
+# ---------------------------------------------------------------------
+
+
+def attach_learner_perc():
+    "return a keyed instance of perceptron learner"
+    learner = sk.Perceptron(n_iter=LOCAL_PERC_ARGS.iterations)
+    return Keyed('perc', SklearnAttachClassifier(learner))
+
+
+def label_learner_perc():
+    "return a keyed instance of perceptron learner"
+    learner = sk.Perceptron(n_iter=LOCAL_PERC_ARGS.iterations)
+    return Keyed('perc', SklearnLabelClassifier(learner))
+
+
+def attach_learner_pa():
+    "return a keyed instance of passive aggressive learner"
+    learner = sk.PassiveAggressiveClassifier(n_iter=LOCAL_PA_ARGS.iterations)
+    return Keyed('pa', SklearnAttachClassifier(learner))
+
+
+def label_learner_pa():
+    "return a keyed instance of passive aggressive learner"
+    learner = sk.PassiveAggressiveClassifier(n_iter=LOCAL_PA_ARGS.iterations)
+    return Keyed('pa', SklearnLabelClassifier(learner))
+
+
+# ---------------------------------------------------------------------
+# dp
+# ---------------------------------------------------------------------
+
+def attach_learner_dp_perc():
+    "return a keyed instance of perceptron learner"
+    return Keyed('dp-perc',
+                 SklearnAttachClassifier(Perceptron(LOCAL_PERC_ARGS)))
+
+
+def label_learner_dp_perc():
+    "return a keyed instance of perceptron learner"
+    return Keyed('dp-perc',
+                 SklearnLabelClassifier(Perceptron(LOCAL_PERC_ARGS)))
+
+
+def attach_learner_dp_pa():
+    "return a keyed instance of passive aggressive learner"
+    return Keyed('dp-pa',
+                 SklearnAttachClassifier(PassiveAggressive(LOCAL_PA_ARGS)))
+
+
+def label_learner_dp_pa():
+    "return a keyed instance of passive aggressive learner"
+    return Keyed('dp-pa',
+                 SklearnLabelClassifier(PassiveAggressive(LOCAL_PA_ARGS)))
+
+
+def attach_learner_dp_struct_perc(decoder):
+    "structured perceptron learning"
+    learner = StructuredPerceptron(decoder, STRUCT_PERC_ARGS)
+    return Keyed('dp-struct-perc', learner)
+
+
+def attach_learner_dp_struct_pa(decoder):
+    "structured passive-aggressive learning"
+    learner = StructuredPassiveAggressive(decoder, STRUCT_PA_ARGS)
+    return Keyed('dp-struct-pa', learner)

--- a/stac/harness/local.py
+++ b/stac/harness/local.py
@@ -13,7 +13,6 @@ import itertools as itr
 import six
 
 import educe.stac.corpus
-import numpy as np
 
 from attelo.harness.config import (EvaluationConfig,
                                    LearnerConfig,
@@ -26,11 +25,6 @@ from attelo.decoding.astar import (AstarArgs,
 from attelo.decoding.baseline import (LastBaseline,
                                       LocalBaseline)
 from attelo.decoding.mst import (MstDecoder, MstRootStrategy)
-from attelo.learning.perceptron import (Perceptron,
-                                        PerceptronArgs,
-                                        PassiveAggressive,
-                                        StructuredPerceptron,
-                                        StructuredPassiveAggressive)
 from attelo.learning.local import (SklearnAttachClassifier,
                                    SklearnLabelClassifier)
 from attelo.learning.oracle import (AttachOracle, LabelOracle)
@@ -45,12 +39,19 @@ from attelo.parser.pipeline import (Pipeline)
 from attelo.util import (concat_l)
 
 from sklearn.linear_model import (LogisticRegression,
-                                  Perceptron as SkPerceptron,
-                                  PassiveAggressiveClassifier as
-                                  SkPassiveAggressiveClassifier)
+                                 )
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.ensemble import RandomForestClassifier
 
+
+# from .config.perceptron import (attach_learner_dp_pa,
+#                                 attach_learner_dp_perc,
+#                                 attach_learner_pa,
+#                                 attach_learner_perc,
+#                                 label_learner_dp_pa,
+#                                 label_learner_dp_perc,
+#                                 attach_learner_pa,
+#                                 attach_learner_perc)
 
 from .turn_constraint import (tc_decoder,
                               tc_learner)
@@ -209,28 +210,6 @@ def label_learner_rndforest():
     "return a keyed instance of decision tree learner"
     return Keyed('rndforest', SklearnLabelClassifier(RandomForestClassifier()))
 
-
-
-LOCAL_PERC_ARGS = PerceptronArgs(iterations=20,
-                                 averaging=True,
-                                 use_prob=False,
-                                 aggressiveness=np.inf)
-
-LOCAL_PA_ARGS = PerceptronArgs(iterations=20,
-                               averaging=True,
-                               use_prob=False,
-                               aggressiveness=np.inf)
-
-STRUCT_PERC_ARGS = PerceptronArgs(iterations=50,
-                                  averaging=True,
-                                  use_prob=False,
-                                  aggressiveness=np.inf)
-
-STRUCT_PA_ARGS = PerceptronArgs(iterations=50,
-                                averaging=True,
-                                use_prob=False,
-                                aggressiveness=np.inf)
-
 ORACLE = LearnerConfig(attach=attach_learner_oracle(),
                        label=label_learner_oracle())
 
@@ -244,18 +223,14 @@ _LOCAL_LEARNERS = [
 #                  label=label_learner_oracle()),
 #    LearnerConfig(attach=attach_learner_rndforest(),
 #                  label=label_learner_rndforest()),
-#    LearnerConfig(attach=Keyed('sk-perceptron',
-#                               SkPerceptron(n_iter=20)),
-#                  label=learner_maxent()),
-#    LearnerConfig(attach=Keyed('sk-pasagg',
-#                               SkPassiveAggressiveClassifier(n_iter=20)),
-#                  label=learner_maxent()),
-#    LearnerConfig(attach=Keyed('dp-perc',
-#                               Perceptron(d, LOCAL_PERC_ARGS)),
-#                  label=learner_maxent()),
-#    LearnerConfig(attach=Keyed('dp-pa',
-#                               PassiveAggressive(d, LOCAL_PA_ARGS)),
-#                  label=learner_maxent()),
+    #    LearnerConfig(attach=attach_learner_perc(),
+    #                  label=label_learner_maxent()),
+    #    LearnerConfig(attach=attach_learner_pa(),
+    #                  label=label_learner_maxent()),
+    #    LearnerConfig(attach=attach_learner_dp_perc(),
+    #                  label=label_learner_maxent()),
+    #    LearnerConfig(attach=attach_learner_dp_pa(),
+    #                  label=label_learner_maxent()),
 ]
 """Straightforward attelo learner algorithms to try
 
@@ -265,23 +240,11 @@ between different configurations of your learners.
 """
 
 
-def attach_learner_dp_struct_perc(decoder):
-    "structured perceptron learning"
-    learner = StructuredPassiveAggressive(decoder, STRUCT_PERC_ARGS)
-    return Keyed('dp-struct-perc', learner)
-
-
-def attach_learner_dp_struct_pa(decoder):
-    "structured passive-aggressive learning"
-    learner = StructuredPassiveAggressive(decoder, STRUCT_PA_ARGS)
-    return Keyed('dp-struct-pa', learner)
-
-
 _STRUCTURED_LEARNERS = [
-#    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_perc(d)),
-#                            label=label_learner_maxent()),
-#    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_pa(d)),
-#                            label=label_learner_maxent()),
+    #    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_perc(d)),
+    #                            label=label_learner_maxent()),
+    #    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_pa(d)),
+    #                            label=label_learner_maxent()),
 ]
 
 """Attelo learners that take decoders as arguments.

--- a/stac/harness/local.py
+++ b/stac/harness/local.py
@@ -238,8 +238,8 @@ _LOCAL_LEARNERS = [
 #    ORACLE,
 #    LearnerConfig(attach=attach_learner_maxent(),
 #                  label=label_learner_maxent()),
-#    LearnerConfig(attach=tc_learner(attach_learner_maxent()),
-#                  label=tc_learner(label_learner_maxent())),
+    LearnerConfig(attach=tc_learner(attach_learner_maxent()),
+                  label=tc_learner(label_learner_maxent())),
 #    LearnerConfig(attach=attach_learner_maxent(),
 #                  label=label_learner_oracle()),
 #    LearnerConfig(attach=attach_learner_rndforest(),
@@ -278,10 +278,10 @@ def attach_learner_dp_struct_pa(decoder):
 
 
 _STRUCTURED_LEARNERS = [
-    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_perc(d)),
-                            label=label_learner_maxent()),
-    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_pa(d)),
-                            label=label_learner_maxent()),
+#    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_perc(d)),
+#                            label=label_learner_maxent()),
+#    lambda d: LearnerConfig(attach=tc_learner(attach_learner_dp_struct_pa(d)),
+#                            label=label_learner_maxent()),
 ]
 
 """Attelo learners that take decoders as arguments.

--- a/stac/harness/local.py
+++ b/stac/harness/local.py
@@ -235,11 +235,11 @@ ORACLE = LearnerConfig(attach=attach_learner_oracle(),
                        label=label_learner_oracle())
 
 _LOCAL_LEARNERS = [
-    ORACLE,
+#    ORACLE,
 #    LearnerConfig(attach=attach_learner_maxent(),
 #                  label=label_learner_maxent()),
-    LearnerConfig(attach=tc_learner(attach_learner_maxent()),
-                  label=tc_learner(label_learner_maxent())),
+#    LearnerConfig(attach=tc_learner(attach_learner_maxent()),
+#                  label=tc_learner(label_learner_maxent())),
 #    LearnerConfig(attach=attach_learner_maxent(),
 #                  label=label_learner_oracle()),
 #    LearnerConfig(attach=attach_learner_rndforest(),

--- a/stac/harness/local.py
+++ b/stac/harness/local.py
@@ -321,14 +321,16 @@ def mk_post(klearner, kdecoder):
 def _core_parsers(klearner):
     """Our basic parser configurations
     """
-    return [
-        # joint
+    # joint
+    joint = [
         #mk_joint(klearner, decoder_last()),
         #mk_joint(klearner, decoder_local()),
         #mk_joint(klearner, decoder_mst()),
         #mk_joint(klearner, tc_decoder(decoder_local())),
         #mk_joint(klearner, tc_decoder(decoder_mst())),
+    ]
 
+    post = [
         # postlabeling
         mk_post(klearner, decoder_last()),
         mk_post(klearner, decoder_local()),
@@ -336,6 +338,10 @@ def _core_parsers(klearner):
         #mk_post(klearner, tc_decoder(decoder_local())),
         mk_post(klearner, tc_decoder(decoder_mst())),
     ]
+    if klearner.attach.payload.can_predict_proba:
+        return joint + post
+    else:
+        return post
 
 
 _INTRA_INTER_CONFIGS = [
@@ -423,7 +429,7 @@ def _mk_last_intras(klearner, kconf):
     """
     kconf = Keyed(key=combined_key('last', kconf),
                   payload=kconf.payload)
-    econf_last = mk_joint(klearner, decoder_last())
+    econf_last = mk_post(klearner, decoder_last())
     return [_combine_intra(IntraInterPair(intra=econf_last, inter=p),
                            kconf,
                            primary='inter')


### PR DESCRIPTION
Part of this pull request is a set of patches to greatly simplify the way we write local.py config files.  If we accept this, we should really port it to irit-rst-dt as well.

Another part is fixing our support for intra/inter decoding and making it more gracefully support the idea of using two separate parsers, possibly with separate learners.
