### PR TITLE
FIX csvtoglozz conditional exec of main

### DIFF
--- a/intake/csvtoglozz.py
+++ b/intake/csvtoglozz.py
@@ -533,4 +533,6 @@ def main():
 
     save_output(filename.split(".")[0], txt, xml)
 
-main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR enables to import and load functions from `csvtoglozz` without executing its `main`.
