### PR TITLE
FIX template for ILP solver: subord relations

### DIFF
--- a/stac/harness/ilp.py
+++ b/stac/harness/ilp.py
@@ -10,6 +10,7 @@ from tempfile import mkdtemp
 from shutil import rmtree
 from subprocess import call
 
+from educe.stac.annotation import SUBORDINATING_RELATIONS
 from attelo.table import UNRELATED
 from attelo.decoding import Decoder
 
@@ -218,11 +219,20 @@ def mk_zimpl_input(dpack, data_dir):
     with open(data_path, 'w') as f_data:
         print(pretty_data(last_mat), file=f_data)
 
+    # class indices that correspond to subordinating relations ;
+    # required for the ILP formulation of the Right Frontier Constraint
+    # in SCIP/ZIMPL
+    subord_idc = [i for i, lbl in enumerate(dpack.labels, start=1)
+                  if lbl in set(SUBORDINATING_RELATIONS)]
+
     header = '\n'.join((
         "param EDU_COUNT := {0} ;".format(len(edus)),
         "param TURN_COUNT := {0} ;".format(len(turn_off)),
         "param PLAYER_COUNT := {0} ;".format(len(speakers)),
         "param LABEL_COUNT := {0} ;".format(len(dpack.labels)),
+        "set RSub := {{{0}}} ;".format(
+            ', '.join(str(i) for i in subord_idc)),
+        "param SUB_LABEL_COUNT := {0} ;".format(len(subord_idc)),
     ))
 
     template_path = fp.join(ZPL_TEMPLATE_DIR, 'template.zpl')

--- a/stac/harness/ilp/template.zpl
+++ b/stac/harness/ilp/template.zpl
@@ -5,14 +5,14 @@
 # param TURN_COUNT := ??? ;
 # param PLAYER_COUNT := ??? ;
 # param LABEL_COUNT := ??? ;
+# set RSub := {4, 5, 7, 8, 10, 13, 15, 18, 19} ;
+# param SUB_LABEL_COUNT := 9 ;
 
 set EDUs := {1 to EDU_COUNT} ;
 set Turns := {1 to TURN_COUNT} ;
 set Labels := {1 to LABEL_COUNT} ;
 set CSPs := {<i,j> in EDUs*EDUs with i < j} ;
 set CSTs := {<i,j,k> in EDUs*EDUs*EDUs with i < j and j < k} ;
-set RSub := {4, 5, 7, 8, 10, 13, 15, 18, 19} ;
-param SUB_LABEL_COUNT := 9 ;
 
 param TLEN[Turns] := read "./turn.dat" as "n+" ;
 param TOFF[Turns] := read "./turn.dat" as "n+" skip 1 ;


### PR DESCRIPTION
This PR replaces a hard-coded list of relation indices with an instantiation that follows the list of labels in the relevant datapack.
This guarantees that the ILP decoder will behave as expected even if labels are enumerated in a different order.