### PR TITLE
FIX gen5: restore Server messages Type *ADDTIME*

### DIFF
--- a/intake/soclogtocsv.py
+++ b/intake/soclogtocsv.py
@@ -77,7 +77,7 @@ EVENTS = {
         # private by rights but treating as public
         # because it's so useful
         "can't end your turn yet",
-        'Type *ADDTIME* to',
+        # 'Type *ADDTIME* to',  # wrong regex: stars need escaping :-/
         'game will expire in',
         'has won the game',
         'discarded',
@@ -107,6 +107,10 @@ EVENTS = {
         'bought a development card',  # action a player can perform ; useful?
         # 'cards left.',  # number of cards left ; useful? NA says no
     ],
+    # 5: bugfix for gen4, incorrect regex for "Type *ADDTIME*"
+    5: [
+        'Type \*ADDTIME\* to',  # wrong regex: stars need escaping :-/
+    ]
 }
 
 # private messages: explicitly ignored
@@ -336,6 +340,12 @@ def guess_generation(event):
         Generation this event belongs to.
     """
     for gen_key, gen_events in EVENTS.items():
+        # 2017-03-21 ugly local fix to undo escaping of stars (MM);
+        # another solution would be to use re.escape() in the expression
+        # for SERVER_RE, but we are in a hurry and I am worried about
+        # potential side effects
+        gen_events = [x.replace('\*', '*') for x in gen_events]
+        # end ugly local fix
         if any(x in event for x in gen_events):
             gen = gen_key
             break

--- a/segmentation/segmentation.py
+++ b/segmentation/segmentation.py
@@ -143,6 +143,11 @@ def fuse_segments(t,xs):
     # 2017-03-09 Game State message: resource count for each player
     resource_count = r'(.* has \d* resource(s)?\.)'
     # end Game State message
+    # 2017-03-21 time left Server message
+    # ">>> Less than X minutes remaining. Type *ADDTIME* to
+    # extend this game another Y minutes."
+    time_left = r'(>>> Less than \d+ minutes remaining[\.])'
+    # end time left Server message
     interjections  = [ r'a+r*g*h+'
                      , 'bah'
                      , 'eww'
@@ -158,7 +163,7 @@ def fuse_segments(t,xs):
     fusible_left_re  = re.compile('|'.join(fusible_left), flags=re.IGNORECASE)
 
     # should be fused with its right neighbour
-    fusible_right    = [resource_alloc, resource_count, interjection]
+    fusible_right = [resource_alloc, resource_count, interjection, time_left]
     fusible_right_re = re.compile('|'.join(fusible_right), flags=re.IGNORECASE)
 
     if len(xs) < 2:


### PR DESCRIPTION
This PR rolls a 5th generation of events, with "Type *ADDTIME*" Server messages that were thought to be in gen3:
```
>>> Less than 9 minutes remaining.  Type *ADDTIME* to extend this game another 30 minutes.
```
