### PR TITLE
MAINT rename csv submodules, remove dep on sh

### DIFF
--- a/intake/create-glozz-aam.py
+++ b/intake/create-glozz-aam.py
@@ -20,7 +20,7 @@ import itertools
 import sys
 import xml.etree.ElementTree as ET
 
-import educe.stac.util.csv as stac_csv
+import educe.stac.util.stac_csv_format as stac_csv
 
 # ---------------------------------------------------------------------
 # template

--- a/intake/csvtoglozz.py
+++ b/intake/csvtoglozz.py
@@ -54,7 +54,7 @@ import sys
 import time
 
 from educe.stac.util.prettifyxml import prettify
-from educe.stac.util.csv import Turn
+from educe.stac.util.stac_csv_format import Turn
 
 
 class Span(namedtuple('Span', 'left right')):

--- a/intake/soclogtocsv.py
+++ b/intake/soclogtocsv.py
@@ -38,7 +38,7 @@ import re
 import string
 import sys
 
-from educe.stac.util import csv as stac_csv
+from educe.stac.util import stac_csv_format as stac_csv
 
 # TODO write tests for these
 TEST1 = ("2011:10:10:17:46:57:481:+0100:GAME-TEXT-MESSAGE:"

--- a/segmentation/normalise-csv
+++ b/segmentation/normalise-csv
@@ -17,7 +17,7 @@ import os
 import os.path
 import sys
 
-import educe.stac.util.csv
+import educe.stac.util.stac_csv_format
 
 if len(sys.argv) == 3:
     filename_in  = sys.argv[1]
@@ -30,7 +30,7 @@ def normalise_file(filename_in, filename_out):
     with open(filename_in, 'rb') as infile:
         with open(filename_out, 'wb') as outfile:
             reader = csv.reader(infile,  delimiter='\t')
-            writer = educe.stac.util.csv.mk_plain_writer(outfile)
+            writer = educe.stac.util.stac_csv_format.mk_plain_writer(outfile)
             for row in reader:
                 writer.writerow(row)
 

--- a/segmentation/simple-segments
+++ b/segmentation/simple-segments
@@ -21,7 +21,7 @@ import re
 import sys
 
 import segmentation
-import educe.stac.util.csv
+import educe.stac.util.stac_csv_format
 
 def segment_row(t):
     segments = [segmentation.span_text(t,sp) for sp in segmentation.segment(t)]
@@ -64,11 +64,11 @@ else:
     job=lambda t:t
 
 with open(filename_in, 'rb') as infile:
-    reader = educe.stac.util.csv.mk_csv_reader(infile)
+    reader = educe.stac.util.stac_csv_format.mk_csv_reader(infile)
     if args.csv:
         # csv library has built-in utf-8 encoding
         with open(args.output_file, 'wb') as outfile:
-            writer = educe.stac.util.csv.mk_csv_writer(outfile)
+            writer = educe.stac.util.stac_csv_format.mk_csv_writer(outfile)
             writer.writeheader()
             for row in reader:
                 writer.writerow(replace_text(job,row))

--- a/stac/harness/cmd/parse.py
+++ b/stac/harness/cmd/parse.py
@@ -12,7 +12,6 @@ import shutil
 import tempfile
 
 from attelo.harness.util import (makedirs, call, force_symlink)
-import sh
 
 from ..local import (CORENLP_SERVER_DIR, CORENLP_ADDRESS,
                      TAGGER_JAR, LEX_DIR,
@@ -288,8 +287,13 @@ def _copy_results(lconf, output_dir):
     # copy the svg graphs into single flat dir
     graphs_dir = fp.join(output_dir, "graphs")
     makedirs(graphs_dir)
-    svg_files = sh.find(minicorpus_path(lconf, result=True),
-                        "-name", "*.svg", _iter=True)
+    # svg_files = sh.find(minicorpus_path(lconf, result=True),
+    #                     "-name", "*.svg", _iter=True)
+    base_svg_dir = minicorpus_path(lconf, result=True)  # DEBUG
+    svg_files = [os.path.join(dirpath, fname)
+                 for dirpath, dirs, files in os.walk(base_svg_dir)
+                 for fname in (dirs + files)
+                 if fname.endswith('.svg')]
     for svg in (f.strip() for f in svg_files):
         svg2 = fp.join(graphs_dir,
                        fp.basename(fp.dirname(svg)) + ".svg")


### PR DESCRIPTION
This PR fixes two maintenance issues:
* corpus-specific csv submodules in educe were renamed to avoid confusion with stdlib csv,
* the dependency on the sh package is removed, to restore (?) windows support.
This is a companion to irit-melodi/educe#124.