### PR TITLE
FIX include Server msg for expired game, do not segment '... from'

### DIFF
--- a/intake/csvtoglozz.py
+++ b/intake/csvtoglozz.py
@@ -420,6 +420,9 @@ def process_turn(root, dialoguetext, turn, is_player):
         turn_segments = [x for x in re.split('(?<![\\\])&', turn.rawtext)
                          if len(x) > 0]
         turn_segments = [x.replace('\&', '&') for x in turn_segments]
+    elif turn.emitter == 'UI' and turn.rawtext.startswith('... from'):
+        # 2nd part of trade offer: *do not* segment "[...] [from XXX]"
+        turn_segments = [turn.rawtext]  # unique segment
     else:
         pre_segments = [x for x in turn.rawtext.split('. ')]
         if pre_segments:
@@ -427,7 +430,6 @@ def process_turn(root, dialoguetext, turn, is_player):
             turn_segments.append(pre_segments[-1])
         else:
             turn_segments = pre_segments
-        turn_text = '. '.join(turn_segments)
 
     turn_text = ''.join(turn_segments)
     seg_spans = edu_spans(dialoguetext, turn_segments)

--- a/intake/soclogtocsv.py
+++ b/intake/soclogtocsv.py
@@ -113,6 +113,8 @@ EVENTS = {
         # Server messages after the end of game
         'VP',  # enumeration of dev cards that increase VPs
         r'rounds\, and took',  # duration of game
+        # 2017-01-18 time limit expired (3 occurrences, last line in soclog)
+        r'time limit on this game has expired and will now be',
     ]
 }
 

--- a/segmentation/segmentation.py
+++ b/segmentation/segmentation.py
@@ -150,6 +150,9 @@ def fuse_segments(t,xs):
     time_left = r'(>>> Less than \d+ minutes remaining[\.])'
     # 2017-03-22 final scores
     final_scores = r'(.* has \d* points\.)'
+    # 2018-01-19 fix EDU segmentation for second part of trade offer:
+    # "... from gw4s"
+    dots_from = r'(\.\.\.)'  # useless because overridden in csvtoglozz
     # end gen5 messages
     interjections  = [ r'a+r*g*h+'
                      , 'bah'
@@ -167,7 +170,7 @@ def fuse_segments(t,xs):
 
     # should be fused with its right neighbour
     fusible_right = [resource_alloc, resource_count, interjection, time_left,
-                     final_scores]
+                     final_scores, dots_from]
     fusible_right_re = re.compile('|'.join(fusible_right), flags=re.IGNORECASE)
 
     if len(xs) < 2:


### PR DESCRIPTION
This PR fixes two bugs in the intake process:
* Server messages for expired games are now included in the CSVs (and glozz files), because the rare occurrences in our corpus are the last messages in their soclog, we consider them Gen5 messages ;
* UI messages for the second part of trade offers ('... from <player>') are now a unique segment (was: [...] [from <player>]).

The latter was a long-standing bug in our intake process that KT was fixing with a post-processing script.